### PR TITLE
Make minor fixes to use cases (DG)

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -303,7 +303,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 (For all use cases below, the **System** is the `TrackO` and the **Actor** is the `user`, unless specified otherwise)
 
-**Use case: UC01 - Add an order**
+**Use case: UC01 - Adding an order**
 
 **MSS**
 
@@ -319,7 +319,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
   
     Use case resumes at 1.
 
-**Use case: UC02 - Delete an order**
+**Use case: UC02 - Deleting an order**
 
 **MSS**
 
@@ -358,7 +358,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
   
       Use case ends.
 
-**Use case: UC04 - Find orders**
+**Use case: UC04 - Finding orders**
 
 **MSS**
 
@@ -374,7 +374,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     
     Use case ends.
 
-**Use case: UC05 - Add an inventory item**
+**Use case: UC05 - Adding an inventory item**
 
 **MSS**
 
@@ -390,7 +390,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     
     Use case resumes at 1.
 
-**Use case: UC06 - Delete an inventory item**
+**Use case: UC06 - Deleting an inventory item**
 
 **MSS**
 
@@ -411,7 +411,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
-**Use case: UC07 - List all inventory items**
+**Use case: UC07 - Listing all inventory items**
 
 **MSS**
 
@@ -427,7 +427,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case ends.
 
-**Use case: UC08 - Find an inventory item**
+**Use case: UC08 - Finding an inventory item**
 
 **MSS**
 
@@ -443,7 +443,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case ends.
 
-**Use case: UC09 - Tag an inventory item**
+**Use case: UC09 - Tagging an inventory item**
 
 **MSS**
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -317,7 +317,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 - 1a. User inputs incomplete order data. <br>
   - 1a1. System informs user of the incomplete data.
   
-    Use case ends.
+    Use case resumes at 1.
 
 **Use case: UC02 - Delete an order**
 
@@ -335,6 +335,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
   - 1a1. System informs the user of the non-existent order.
     
      Use case ends.
+
 - 2a. The list has no orders.
   
   - 2a1. System informs the user of the empty order list.
@@ -387,7 +388,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 - 1a. User inputs incomplete details of the item.
   - 1a1. System informs user of the incomplete details.
     
-    Use case ends.
+    Use case resumes at 1.
 
 **Use case: UC06 - Delete an inventory item**
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -303,7 +303,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 (For all use cases below, the **System** is the `TrackO` and the **Actor** is the `user`, unless specified otherwise)
 
-**Use case: UC01 - Adding an order**
+**Use case: UC01 - Add an order**
 
 **MSS**
 
@@ -319,7 +319,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
   
     Use case resumes at 1.
 
-**Use case: UC02 - Deleting an order**
+**Use case: UC02 - Delete an order**
 
 **MSS**
 
@@ -342,7 +342,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
   
     Use case ends.
 
-**Use case: UC03 - Listing orders**
+**Use case: UC03 - List orders**
 
 **MSS**
 
@@ -358,7 +358,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
   
       Use case ends.
 
-**Use case: UC04 - Finding orders**
+**Use case: UC04 - Find orders**
 
 **MSS**
 
@@ -374,7 +374,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     
     Use case ends.
 
-**Use case: UC05 - Adding an inventory item**
+**Use case: UC05 - Add an inventory item**
 
 **MSS**
 
@@ -390,7 +390,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     
     Use case resumes at 1.
 
-**Use case: UC06 - Deleting an inventory item**
+**Use case: UC06 - Delete an inventory item**
 
 **MSS**
 
@@ -411,7 +411,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
-**Use case: UC07 - Listing all inventory items**
+**Use case: UC07 - List all inventory items**
 
 **MSS**
 
@@ -427,7 +427,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case ends.
 
-**Use case: UC08 - Finding an inventory item**
+**Use case: UC08 - Find an inventory item**
 
 **MSS**
 
@@ -443,7 +443,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case ends.
 
-**Use case: UC09 - Tagging an inventory item**
+**Use case: UC09 - Tag an inventory item**
 
 **MSS**
 


### PR DESCRIPTION
The following changes are made:

- UC01 (Adding an order) Extensions: Instead of `use case ends`, it is changed to `use case resumes at 1`.
- The same change is implemented for UC05 (Adding an inventory item).
- Standardise the use case titles to verb + ing form (Adding, deleting, etc)


