### PR TITLE
Add Storage support for Inventory items

### DIFF
--- a/src/main/java/tracko/MainApp.java
+++ b/src/main/java/tracko/MainApp.java
@@ -88,7 +88,7 @@ public class MainApp extends Application {
             logger.warning("Data file not in the correct format. Will be starting with an empty TrackO");
             initialData = new TrackO();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting iwth an empty TrackO");
+            logger.warning("Problem while reading from the file. Will be starting with an empty TrackO");
             initialData = new TrackO();
         }
 

--- a/src/main/java/tracko/model/UserPrefs.java
+++ b/src/main/java/tracko/model/UserPrefs.java
@@ -15,7 +15,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
-    private Path ordersFilePath = Paths.get("data", "orders.json");
+    private Path ordersFilePath = Paths.get("data", "trackO.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.

--- a/src/main/java/tracko/storage/JsonAdaptedItem.java
+++ b/src/main/java/tracko/storage/JsonAdaptedItem.java
@@ -1,0 +1,80 @@
+package tracko.storage;
+
+import java.util.HashSet;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import tracko.commons.exceptions.IllegalValueException;
+import tracko.model.items.Description;
+import tracko.model.items.Item;
+import tracko.model.items.ItemName;
+import tracko.model.items.Quantity;
+
+/**
+ * Jackson-friendly version of {@link Item}.
+ */
+public class JsonAdaptedItem {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Item's %s field is missing!";
+
+    private final String itemName;
+    private final Integer quantity;
+    private final String description;
+
+    /**
+     * Constructs a {@code JsonAdaptedItem} with the given item details.
+     */
+    @JsonCreator
+    public JsonAdaptedItem(@JsonProperty("itemName") String itemName, @JsonProperty("quantity") Integer quantity,
+                            @JsonProperty("description") String description) {
+        this.itemName = itemName;
+        this.quantity = quantity;
+        this.description = description;
+    }
+
+    /**
+     * Converts a given {@code Item} into this class for Jackson use.
+     */
+    public JsonAdaptedItem(Item source) {
+        itemName = source.getItemName().itemName;
+        quantity = source.getQuantity().getQuantity();
+        description = source.getDescription().value;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted item object into the model's {@code Item} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted item.
+     */
+    public Item toModelType() throws IllegalValueException {
+
+        if (itemName == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    ItemName.class.getSimpleName()));
+        }
+        if (!ItemName.isValidItemName(itemName)) {
+            throw new IllegalValueException(ItemName.MESSAGE_CONSTRAINTS);
+        }
+        final ItemName modelItemName = new ItemName(itemName);
+
+        if (quantity == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Quantity.class.getSimpleName()));
+        }
+        if (!Quantity.isValidQuantity(quantity)) {
+            throw new IllegalValueException(Quantity.MESSAGE_CONSTRAINTS);
+        }
+        final Quantity modelQuantity = new Quantity(quantity);
+
+        if (description == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Description.class.getSimpleName()));
+        }
+        if (!Description.isValidDescription(description)) {
+            throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
+        }
+        final Description modelDescription = new Description(description);
+
+        return new Item(modelItemName, modelDescription, modelQuantity, new HashSet<>());
+    }
+}

--- a/src/main/java/tracko/storage/JsonSerializableTrackO.java
+++ b/src/main/java/tracko/storage/JsonSerializableTrackO.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import tracko.commons.exceptions.IllegalValueException;
 import tracko.model.ReadOnlyTrackO;
 import tracko.model.TrackO;
+import tracko.model.items.Item;
 import tracko.model.order.Order;
 
 
@@ -20,16 +21,16 @@ import tracko.model.order.Order;
 @JsonRootName(value = "tracko")
 public class JsonSerializableTrackO {
 
-    // TODO: add items here
-
+    private final List<JsonAdaptedItem> items = new ArrayList<>();
     private final List<JsonAdaptedOrder> orders = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableTrackO} with the given orders.
+     * Constructs a {@code JsonSerializableTrackO} with the given orders and items.
      */
     @JsonCreator
-    public JsonSerializableTrackO(@JsonProperty("orders") List<JsonAdaptedOrder> orders) {
-        // TODO: add items here (before orders)
+    public JsonSerializableTrackO(@JsonProperty("items") List<JsonAdaptedItem> items,
+                                  @JsonProperty("orders") List<JsonAdaptedOrder> orders) {
+        this.items.addAll(items);
         this.orders.addAll(orders);
     }
 
@@ -39,7 +40,8 @@ public class JsonSerializableTrackO {
      * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableTrackO(ReadOnlyTrackO source) {
-        // TODO: add items here (before orders)
+
+        items.addAll(source.getInventoryList().stream().map(JsonAdaptedItem::new).collect(Collectors.toList()));
         orders.addAll(source.getOrderList().stream().map(JsonAdaptedOrder::new).collect(Collectors.toList()));
     }
 
@@ -51,6 +53,10 @@ public class JsonSerializableTrackO {
     public TrackO toModelType() throws IllegalValueException {
         // TODO: add items here (before orders)
         TrackO trackO = new TrackO();
+        for (JsonAdaptedItem jsonAdaptedItem : items) {
+            Item item = jsonAdaptedItem.toModelType();
+            trackO.addItem(item);
+        }
         for (JsonAdaptedOrder jsonAdaptedOrder : orders) {
             Order order = jsonAdaptedOrder.toModelType();
             trackO.addOrder(order);

--- a/src/main/java/tracko/storage/JsonTrackOStorage.java
+++ b/src/main/java/tracko/storage/JsonTrackOStorage.java
@@ -21,33 +21,33 @@ public class JsonTrackOStorage implements TrackOStorage {
 
     private static final Logger logger = LogsCenter.getLogger(JsonTrackOStorage.class);
 
-    private Path ordersFilePath;
+    private Path trackOFilePath;
 
-    public JsonTrackOStorage(Path ordersFilePath) {
-        this.ordersFilePath = ordersFilePath;
+    public JsonTrackOStorage(Path trackOFilePath) {
+        this.trackOFilePath = trackOFilePath;
     }
 
-    public Path getOrdersFilePath() {
-        return ordersFilePath;
+    public Path getTrackOFilePath() {
+        return trackOFilePath;
     }
 
     @Override
     public Optional<ReadOnlyTrackO> readTrackO() throws DataConversionException, IOException {
-        return readTrackO(ordersFilePath);
+        return readTrackO(trackOFilePath);
     }
 
     /**
      * Similar to {@link #readTrackO()}
      *
-     * @param ordersFilePath Location of the orders data file. Cannot be null.
+     * @param trackOFilePath Location of the orders data file. Cannot be null.
      * @throws DataConversionException if the file is not in the correct format.
      */
     @Override
-    public Optional<ReadOnlyTrackO> readTrackO(Path ordersFilePath) throws DataConversionException {
-        requireNonNull(ordersFilePath);
+    public Optional<ReadOnlyTrackO> readTrackO(Path trackOFilePath) throws DataConversionException {
+        requireNonNull(trackOFilePath);
 
         Optional<JsonSerializableTrackO> jsonTrackO = JsonUtil.readJsonFile(
-                ordersFilePath, JsonSerializableTrackO.class);
+                trackOFilePath, JsonSerializableTrackO.class);
 
         if (!jsonTrackO.isPresent()) {
             return Optional.empty();
@@ -56,26 +56,26 @@ public class JsonTrackOStorage implements TrackOStorage {
         try {
             return Optional.of(jsonTrackO.get().toModelType());
         } catch (IllegalValueException ive) {
-            logger.info("Illegal values found in " + ordersFilePath + ": " + ive.getMessage());
+            logger.info("Illegal values found in " + trackOFilePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);
         }
     }
 
     @Override
     public void saveTrackO(ReadOnlyTrackO trackO) throws IOException {
-        saveTrackO(trackO, ordersFilePath);
+        saveTrackO(trackO, trackOFilePath);
     }
 
     /**
      * Similar to {@link #saveTrackO(ReadOnlyTrackO)}.
      *
-     * @param ordersFilePath Location of the orders data file. Cannot be null.
+     * @param trackOFilePath Location of the orders data file. Cannot be null.
      */
-    public void saveTrackO(ReadOnlyTrackO trackO, Path ordersFilePath) throws IOException {
+    public void saveTrackO(ReadOnlyTrackO trackO, Path trackOFilePath) throws IOException {
         requireNonNull(trackO);
-        requireNonNull(ordersFilePath);
+        requireNonNull(trackOFilePath);
 
-        FileUtil.createIfMissing(ordersFilePath);
-        JsonUtil.saveJsonFile(new JsonSerializableTrackO(trackO), ordersFilePath);
+        FileUtil.createIfMissing(trackOFilePath);
+        JsonUtil.saveJsonFile(new JsonSerializableTrackO(trackO), trackOFilePath);
     }
 }

--- a/src/main/java/tracko/storage/Storage.java
+++ b/src/main/java/tracko/storage/Storage.java
@@ -23,7 +23,7 @@ public interface Storage extends TrackOStorage, UserPrefsStorage {
     // TrackO methods =================================================================================
 
     @Override
-    Path getOrdersFilePath();
+    Path getTrackOFilePath();
 
     @Override
     Optional<ReadOnlyTrackO> readTrackO() throws DataConversionException, IOException;

--- a/src/main/java/tracko/storage/StorageManager.java
+++ b/src/main/java/tracko/storage/StorageManager.java
@@ -49,30 +49,30 @@ public class StorageManager implements Storage {
     // ============== TrackO methods =========================================
 
     @Override
-    public Path getOrdersFilePath() {
-        return trackOStorage.getOrdersFilePath();
+    public Path getTrackOFilePath() {
+        return trackOStorage.getTrackOFilePath();
     }
 
     @Override
     public Optional<ReadOnlyTrackO> readTrackO() throws DataConversionException, IOException {
-        return readTrackO(trackOStorage.getOrdersFilePath());
+        return readTrackO(trackOStorage.getTrackOFilePath());
     }
 
     @Override
-    public Optional<ReadOnlyTrackO> readTrackO(Path ordersFilePath) throws DataConversionException, IOException {
-        logger.fine("[TrackO] Attempting to read data from file: " + ordersFilePath);
-        return trackOStorage.readTrackO(ordersFilePath);
+    public Optional<ReadOnlyTrackO> readTrackO(Path trackOFilePath) throws DataConversionException, IOException {
+        logger.fine("[TrackO] Attempting to read data from file: " + trackOFilePath);
+        return trackOStorage.readTrackO(trackOFilePath);
     }
 
     @Override
     public void saveTrackO(ReadOnlyTrackO trackO) throws IOException {
-        saveTrackO(trackO, trackOStorage.getOrdersFilePath());
+        saveTrackO(trackO, trackOStorage.getTrackOFilePath());
     }
 
     @Override
-    public void saveTrackO(ReadOnlyTrackO trackO, Path ordersFilePath) throws IOException {
-        logger.fine("[TrackO] Attempting to write to data file: " + ordersFilePath);
-        trackOStorage.saveTrackO(trackO, ordersFilePath);
+    public void saveTrackO(ReadOnlyTrackO trackO, Path trackOFilePath) throws IOException {
+        logger.fine("[TrackO] Attempting to write to data file: " + trackOFilePath);
+        trackOStorage.saveTrackO(trackO, trackOFilePath);
     }
 
 }

--- a/src/main/java/tracko/storage/TrackOStorage.java
+++ b/src/main/java/tracko/storage/TrackOStorage.java
@@ -6,12 +6,13 @@ import java.util.Optional;
 
 import tracko.commons.exceptions.DataConversionException;
 import tracko.model.ReadOnlyTrackO;
+import tracko.model.TrackO;
 
 /**
  * Represents a storage for {@link TrackO}
  */
 public interface TrackOStorage {
-    Path getOrdersFilePath();
+    Path getTrackOFilePath();
 
     /**
      * Returns TrackO data as a {@link ReadOnlyTrackO}
@@ -21,7 +22,7 @@ public interface TrackOStorage {
      */
     Optional<ReadOnlyTrackO> readTrackO() throws DataConversionException, IOException;
 
-    Optional<ReadOnlyTrackO> readTrackO(Path ordersFilePath) throws DataConversionException, IOException;
+    Optional<ReadOnlyTrackO> readTrackO(Path trackOFilePath) throws DataConversionException, IOException;
 
     /**
      * Saves the given {@link ReadOnlyTrackO} to the storage.
@@ -30,5 +31,5 @@ public interface TrackOStorage {
      */
     void saveTrackO(ReadOnlyTrackO trackO) throws IOException;
 
-    void saveTrackO(ReadOnlyTrackO trackO, Path ordersFilePath) throws IOException;
+    void saveTrackO(ReadOnlyTrackO trackO, Path trackOFilePath) throws IOException;
 }

--- a/src/test/java/tracko/logic/LogicManagerTest.java
+++ b/src/test/java/tracko/logic/LogicManagerTest.java
@@ -156,7 +156,7 @@ public class LogicManagerTest {
         }
 
         @Override
-        public void saveTrackO(ReadOnlyTrackO trackO, Path filePath) throws IOException {
+        public void saveTrackO(ReadOnlyTrackO trackO, Path trackOFilePath) throws IOException {
             throw DUMMY_IO_EXCEPTION;
         }
     }

--- a/src/test/java/tracko/storage/StorageManagerTest.java
+++ b/src/test/java/tracko/storage/StorageManagerTest.java
@@ -62,7 +62,7 @@ public class StorageManagerTest {
 
     @Test
     public void getOrdersFilePath() {
-        assertNotNull(storageManager.getOrdersFilePath());
+        assertNotNull(storageManager.getTrackOFilePath());
     }
 
 }


### PR DESCRIPTION
Inventory items will be written into and read from the Json file in the following format: 

```java 
{
  "items" : [ {
    "item name": "key", 
    "quantity": 10, 
    "description": "for kitchen cabinets"
  }], 
  "orders" : [ {
    "name" : "Alex Yeoh",
    "phone" : "87438807",
    "email" : "alexyeoh@example.com",
    "address" : "Blk 30 Geylang Street 29, #06-40",
    "tagged" : [ "friends" ],
    "remark" : "successful businessman"
  }, {
    "name" : "Bernice Yu",
    "phone" : "99272758",
    "email" : "berniceyu@example.com",
    "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
    "tagged" : [ "colleagues", "friends" ],
    "remark" : ""
  } ]
}
```