### PR TITLE
Update index based commands to target filtered list index

### DIFF
--- a/src/main/java/tracko/logic/commands/item/DeleteItemCommand.java
+++ b/src/main/java/tracko/logic/commands/item/DeleteItemCommand.java
@@ -34,7 +34,7 @@ public class DeleteItemCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ObservableList<Item> lastShownList = model.getInventoryList();
+        ObservableList<Item> lastShownList = model.getFilteredItemList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);

--- a/src/main/java/tracko/logic/commands/item/EditItemCommand.java
+++ b/src/main/java/tracko/logic/commands/item/EditItemCommand.java
@@ -64,7 +64,7 @@ public class EditItemCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ObservableList<Item> lastShownList = model.getInventoryList();
+        ObservableList<Item> lastShownList = model.getFilteredItemList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);

--- a/src/main/java/tracko/logic/commands/item/EditItemCommand.java
+++ b/src/main/java/tracko/logic/commands/item/EditItemCommand.java
@@ -23,7 +23,7 @@ import tracko.model.items.Quantity;
 import tracko.model.tag.Tag;
 
 /**
- * Edits the details of an existing person in the address book.
+ * Edits the details of an existing item in the inventory list.
  */
 public class EditItemCommand extends Command {
 
@@ -50,8 +50,8 @@ public class EditItemCommand extends Command {
     private final EditItemDescriptor editItemDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
-     * @param editItemDescriptor details to edit the person with
+     * @param index of the item in the filtered inventory list to edit
+     * @param editItemDescriptor details to edit the item with
      */
     public EditItemCommand(Index index, EditItemDescriptor editItemDescriptor) {
         requireNonNull(index);
@@ -83,8 +83,8 @@ public class EditItemCommand extends Command {
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
-     * edited with {@code editPersonDescriptor}.
+     * Creates and returns a {@code Item} with the details of {@code itemToEdit}
+     * edited with {@code editItemDescriptor}.
      */
     private static Item createEditedItem(Item itemToEdit, EditItemDescriptor editItemDescriptor) {
         assert itemToEdit != null;
@@ -116,8 +116,8 @@ public class EditItemCommand extends Command {
     }
 
     /**
-     * Stores the details to edit the person with. Each non-empty field value will replace the
-     * corresponding field value of the person.
+     * Stores the details to edit the item with. Each non-empty field value will replace the
+     * corresponding field value of the item.
      */
     public static class EditItemDescriptor {
         private ItemName itemName;

--- a/src/main/java/tracko/logic/commands/order/DeleteOrderCommand.java
+++ b/src/main/java/tracko/logic/commands/order/DeleteOrderCommand.java
@@ -34,7 +34,7 @@ public class DeleteOrderCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ObservableList<Order> lastShownList = model.getOrderList();
+        ObservableList<Order> lastShownList = model.getFilteredOrderList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);

--- a/src/main/java/tracko/model/Model.java
+++ b/src/main/java/tracko/model/Model.java
@@ -109,7 +109,7 @@ public interface Model {
     void setItem(Item target, Item editedItem);
 
     /**
-     * Returns an unmodifiable view of the filtered person list.
+     * Returns an unmodifiable view of the filtered item list.
      */
     ObservableList<Item> getFilteredItemList();
 

--- a/src/main/java/tracko/model/TrackO.java
+++ b/src/main/java/tracko/model/TrackO.java
@@ -27,7 +27,7 @@ public class TrackO implements ReadOnlyTrackO {
     public TrackO() {}
 
     /**
-     * Creates an AddressBook using the data in the {@code toBeCopied}
+     * Creates a TrackO using the data in the {@code toBeCopied}
      */
     public TrackO(ReadOnlyTrackO toBeCopied) {
         this();
@@ -43,7 +43,7 @@ public class TrackO implements ReadOnlyTrackO {
     }
 
     /**
-     * Resets the existing data of this {@code AddressBook} with {@code newData}.
+     * Resets the existing data of this {@code TrackO} with {@code newData}.
      */
     public void resetData(ReadOnlyTrackO newData) {
         requireNonNull(newData);


### PR DESCRIPTION
Update `deletei` `editi` `deleteo` to target indexes based on the filtered inventory and order lists rather than the entire lists.