### PR TITLE
Add functionality to verify stock for delivery

### DIFF
--- a/src/main/java/tracko/commons/core/Messages.java
+++ b/src/main/java/tracko/commons/core/Messages.java
@@ -14,4 +14,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_ITEM_DISPLAYED_INDEX = "The item index provided is invalid";
     public static final String MESSAGE_ORDER_ALREADY_DELIVERED = "Order has been delivered previously";
     public static final String MESSAGE_ORDER_ALREADY_PAID = "Order has already been paid for";
+    public static final String MESSAGE_INSUFFICIENT_STOCK =
+            "There is insufficient stock in the inventory to deliver order";
 }

--- a/src/main/java/tracko/model/Model.java
+++ b/src/main/java/tracko/model/Model.java
@@ -73,6 +73,10 @@ public interface Model {
      */
     void deleteOrder(Order order);
 
+    void setOrder(Order orderToEdit, Order editedOrder);
+
+    void markOrder(Order orderToMark, boolean isPaid, boolean isDelivered);
+
     /**
      * Returns the order list.
      */
@@ -153,8 +157,6 @@ public interface Model {
      * Returns the item list.
      */
     ObservableList<Item> getInventoryList();
-
-    void setOrder(Order orderToEdit, Order editedOrder);
 
     void refreshData();
 }

--- a/src/main/java/tracko/model/ModelManager.java
+++ b/src/main/java/tracko/model/ModelManager.java
@@ -119,6 +119,26 @@ public class ModelManager implements Model {
         trackO.setOrder(orderToEdit, editedOrder);
     }
 
+    @Override
+    public void markOrder(Order orderToMark, boolean isPaid, boolean isDelivered) {
+        requireNonNull(orderToMark);
+
+        if (isPaid) {
+            orderToMark.setPaid();
+        }
+
+        // decreases the quantity of each item delivered in the inventory list according to the quantity delivered
+        if (isDelivered) {
+            getInventoryList().stream().forEach(item -> orderToMark.getItemList().stream().forEach(orderItem -> {
+                if (item.isSameItem(orderItem.getItem())) {
+                    item.reduceItem(orderItem.getQuantityValue());
+                }
+            }));
+
+            orderToMark.setDelivered();
+        }
+    }
+
     // FILTERED ORDER LIST ACCESSORS ========================================================================
 
 

--- a/src/main/java/tracko/model/item/Item.java
+++ b/src/main/java/tracko/model/item/Item.java
@@ -53,6 +53,10 @@ public class Item {
         return totalQuantity;
     }
 
+    public Integer getTotalQuantityValue() {
+        return totalQuantity.getQuantity();
+    }
+
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
     }
@@ -63,6 +67,15 @@ public class Item {
 
     public Price getCostPrice() {
         return costPrice;
+    }
+
+    /**
+     * Decreases the stock quantity of the item by the delivered amount.
+     * @param deliveredQuantity quantity of the item that has been delivered
+     */
+    public void reduceItem(Integer deliveredQuantity) {
+        Quantity newQuantity = new Quantity(this.totalQuantity.getQuantity() - deliveredQuantity);
+        this.totalQuantity = newQuantity;
     }
 
     /**

--- a/src/main/java/tracko/model/order/Order.java
+++ b/src/main/java/tracko/model/order/Order.java
@@ -103,6 +103,12 @@ public class Order {
         return timeCreated;
     }
 
+    public boolean isDeliverable() {
+        return itemList.stream()
+                        .map(pair -> pair.getQuantityValue() < pair.getItem().getTotalQuantityValue())
+                        .anyMatch(x -> x == true);
+    }
+
     public boolean isCompleted() {
         return isPaid && isDelivered;
     }

--- a/src/test/java/tracko/logic/commands/AddOrderCommandTest.java
+++ b/src/test/java/tracko/logic/commands/AddOrderCommandTest.java
@@ -131,6 +131,11 @@ public class AddOrderCommandTest {
         }
 
         @Override
+        public void markOrder(Order orderToMark, boolean isPaid, boolean isDelivered) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Order> getOrderList() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
This commit adds the functionality of validating that there are sufficient stock before a user is allowed to mark an order as delivered.

Furthermore, upon marking an order as delivered, the quantity of stock for delivered items will be decremented correspondingly in the inventory list.

Currently this PR does not include tests or UG/DG update. UG/DG update for this functionality will be added in a separate PR. 
