### PR TITLE
Move method to item quantity in inventory

### DIFF
--- a/src/main/java/tracko/model/ModelManager.java
+++ b/src/main/java/tracko/model/ModelManager.java
@@ -123,20 +123,7 @@ public class ModelManager implements Model {
     public void markOrder(Order orderToMark, boolean isPaid, boolean isDelivered) {
         requireNonNull(orderToMark);
 
-        if (isPaid) {
-            orderToMark.setPaid();
-        }
-
-        // decreases the quantity of each item delivered in the inventory list according to the quantity delivered
-        if (isDelivered) {
-            getInventoryList().stream().forEach(item -> orderToMark.getItemList().stream().forEach(orderItem -> {
-                if (item.isSameItem(orderItem.getItem())) {
-                    item.reduceItem(orderItem.getQuantityValue());
-                }
-            }));
-
-            orderToMark.setDelivered();
-        }
+        trackO.markOrder(orderToMark, isPaid, isDelivered);
     }
 
     // FILTERED ORDER LIST ACCESSORS ========================================================================

--- a/src/main/java/tracko/model/TrackO.java
+++ b/src/main/java/tracko/model/TrackO.java
@@ -64,6 +64,25 @@ public class TrackO implements ReadOnlyTrackO {
         orders.delete(order);
     }
 
+    /**
+     * Marks an order as paid and/or delivered
+     * @param order order to be marked
+     * @param isPaid true when order is to be marked paid
+     * @param isDelivered true when order is to be marked delivered
+     */
+    public void markOrder(Order order, boolean isPaid, boolean isDelivered) {
+        if (isPaid) {
+            order.setPaid();
+        }
+
+        // decreases the quantity of each item delivered in the inventory list according to the quantity delivered
+        if (isDelivered) {
+            items.reduceItems(order);
+
+            order.setDelivered();
+        }
+    }
+
     @Override
     public ObservableList<Order> getOrderList() {
         return orders.asUnmodifiableObservableList();

--- a/src/main/java/tracko/model/item/InventoryList.java
+++ b/src/main/java/tracko/model/item/InventoryList.java
@@ -10,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import tracko.model.item.exceptions.DuplicateItemException;
 import tracko.model.item.exceptions.ItemNotFoundException;
+import tracko.model.order.Order;
 
 /**
  * Represents the list of items in the inventory.
@@ -56,6 +57,20 @@ public class InventoryList implements Iterable<Item> {
     public void delete(Item toDelete) {
         requireNonNull(toDelete);
         internalList.remove(toDelete);
+    }
+
+    /**
+     * Decreases quantity of items in Inventory list according to items in order
+     * that was marked as delivered
+     * @param deliveredOrder order that was delivered
+     */
+    public void reduceItems(Order deliveredOrder) {
+        // decreases the quantity of each item delivered in the inventory list according to the quantity delivered
+        internalList.stream().forEach(item -> deliveredOrder.getItemList().stream().forEach(orderItem -> {
+            if (item.isSameItem(orderItem.getItem())) {
+                item.reduceItem(orderItem.getQuantityValue());
+            }
+        }));
     }
 
     /**


### PR DESCRIPTION
Restructure code to reduce quantity of items in inventory according to item quantity delivered an order. 

This restructure mainly aims to : 
- respect the segregation of concerns across classes (i.e. ModelManager should not be concerned with the implementation of decreasing inventory quantity)
- Readability of code (reduce nesting of code to maximum 3 levels of indentation)