### PR TITLE
Finalize UI

### DIFF
--- a/src/main/java/tracko/logic/commands/order/EditOrderCommand.java
+++ b/src/main/java/tracko/logic/commands/order/EditOrderCommand.java
@@ -55,6 +55,7 @@ public class EditOrderCommand extends Command {
             + "not exist in the inventory list.";
     public static final String MESSAGE_ONE_ORDERED_ITEM = "An order list cannot have 0 items. "
             + "Perhaps you want to delete the order instead?";
+    public static final String MESSAGE_ORDER_ALREADY_COMPLETED = "A completed order cannot be edited!";
 
     private final Index index;
     private final EditOrderDescriptor editOrderDescriptor;
@@ -81,6 +82,11 @@ public class EditOrderCommand extends Command {
         }
 
         Order orderToEdit = lastShownList.get(index.getZeroBased());
+
+        if (orderToEdit.isCompleted()) {
+            throw new CommandException(MESSAGE_ORDER_ALREADY_COMPLETED);
+        }
+
         Order editedOrder = createEditedOrder(orderToEdit, editOrderDescriptor, model);
 
         model.setOrder(orderToEdit, editedOrder);

--- a/src/main/java/tracko/logic/commands/order/EditOrderCommand.java
+++ b/src/main/java/tracko/logic/commands/order/EditOrderCommand.java
@@ -75,7 +75,7 @@ public class EditOrderCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Order> lastShownList = model.getFilteredOrderList();
+        List<Order> lastShownList = model.getSortedOrderList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);

--- a/src/main/java/tracko/ui/ItemCard.java
+++ b/src/main/java/tracko/ui/ItemCard.java
@@ -73,12 +73,10 @@ public class ItemCard extends UiPart<Region> {
         sellPrice.setText("$" + inventoryItem.getSellPrice().toString());
         sellPrice.setWrapText(true);
         sellPrice.setPadding(new Insets(0, 10, 0, 0));
-        sellPrice.setMinWidth(150);
 
         costPrice.setText("$" + inventoryItem.getCostPrice().toString());
         costPrice.setWrapText(true);
         costPrice.setPadding(new Insets(0, 10, 0, 0));
-        costPrice.setMinWidth(150);
 
         inventoryItem.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/tracko/ui/OrderCard.java
+++ b/src/main/java/tracko/ui/OrderCard.java
@@ -2,7 +2,6 @@ package tracko.ui;
 
 import javafx.fxml.FXML;
 import javafx.geometry.Insets;
-import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
@@ -53,6 +52,12 @@ public class OrderCard extends UiPart<Region> {
     private HBox dateContainer;
     @FXML
     private HBox orderStatus;
+    @FXML
+    private HBox totalOrderPriceContainer;
+    @FXML
+    private Region totalPriceIcon;
+    @FXML
+    private Region timeCreatedIcon;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -60,14 +65,12 @@ public class OrderCard extends UiPart<Region> {
     public OrderCard(Order order, int displayedIndex) {
         super(FXML);
         this.order = order;
+
         id.setText(Integer.toString(displayedIndex));
+
         name.setText(order.getName().fullName);
         name.setWrapText(true);
         name.setPadding(new Insets(0, 10, 0, 0));
-
-        // If name consists of more than 1 line, this will align the id to the first line.
-        id.prefHeightProperty().bind(name.heightProperty());
-        id.setAlignment(Pos.TOP_LEFT);
 
         phone.setText(order.getPhone().value);
         phone.setWrapText(true);
@@ -85,21 +88,6 @@ public class OrderCard extends UiPart<Region> {
         email.setWrapText(true);
         email.setPadding(new Insets(0, 10, 0, 0));
 
-        setOrderStatusStyle();
-
-        totalOrderPrice.setText("$" + String.format("%.2f", order.calculateTotalOrderPrice()));
-        totalOrderPrice.setWrapText(true);
-        totalOrderPrice.setPadding(new Insets(0, 10, 0, 0));
-
-        items.setPadding(new Insets(8, 10, 8, 10));
-        items.setStyle("-fx-background-insets: 5 0 5 0;");
-        items.getStyleClass().add("ordered-items-container");
-        order.getItemList().stream()
-                .forEach(pair -> items.getChildren().add(
-                        constructItemLabel(pair.toString())));
-    }
-
-    public void setOrderStatusStyle() {
         if (order.getPaidStatus()) {
             paidStatus.setText("Paid");
             paidStatus.setStyle("-fx-background-color: #D9DCFF; -fx-text-fill: #707BE3");
@@ -116,12 +104,36 @@ public class OrderCard extends UiPart<Region> {
             deliveryStatus.setStyle("-fx-background-color: #FF6C64; -fx-text-fill: #FFEDEC");
         }
 
+        totalOrderPrice.setText("$" + String.format("%.2f", order.calculateTotalOrderPrice()));
+        totalOrderPrice.setWrapText(true);
+        totalOrderPrice.setPadding(new Insets(0, 10, 0, 0));
+
         if (order.isCompleted()) {
-            paidStatus.setText("Completed");
-            paidStatus.setStyle("-fx-background-color: #DFDFEB; -fx-text-fill: #7A7CA5");
-            deliveryStatus.setText(null);
-            deliveryStatus.setStyle("-fx-background-color: #7A7CA5");
+            setCompletedStyle();
         }
+
+        items.setPadding(new Insets(8, 10, 8, 10));
+        items.setStyle("-fx-background-insets: 5 0 5 0;");
+        items.getStyleClass().add("ordered-items-container");
+        order.getItemList().stream()
+                .forEach(pair -> items.getChildren().add(
+                        constructItemLabel(pair.toString())));
+    }
+
+    /**
+     * Changes the colors of the order card elements to faded colors after an order is completed.
+     */
+    public void setCompletedStyle() {
+        paidStatus.setText("Completed");
+        paidStatus.setStyle("-fx-background-color: #DFDFEB; -fx-text-fill: #7A7CA5");
+        deliveryStatus.setText(null);
+        deliveryStatus.setStyle("-fx-background-color: #7A7CA5");
+        totalOrderPriceContainer.setStyle("-fx-background-color: #C4EAC8 !important;");
+        totalOrderPrice.setStyle("-fx-text-fill: #678D6C !important;");
+        totalPriceIcon.setStyle("-fx-background-color: #678D6C !important;");
+        timeCreated.setStyle("-fx-text-fill: #AA9787 !important;");
+        dateContainer.setStyle("-fx-background-color: #FAF4EF !important;");
+        timeCreatedIcon.setStyle("-fx-background-color: #AA9787 !important;");
     }
 
     /**

--- a/src/main/java/tracko/ui/OrderCard.java
+++ b/src/main/java/tracko/ui/OrderCard.java
@@ -51,6 +51,8 @@ public class OrderCard extends UiPart<Region> {
     private VBox items;
     @FXML
     private HBox dateContainer;
+    @FXML
+    private HBox orderStatus;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -83,10 +85,21 @@ public class OrderCard extends UiPart<Region> {
         email.setWrapText(true);
         email.setPadding(new Insets(0, 10, 0, 0));
 
+        setOrderStatusStyle();
+
         totalOrderPrice.setText("$" + String.format("%.2f", order.calculateTotalOrderPrice()));
         totalOrderPrice.setWrapText(true);
         totalOrderPrice.setPadding(new Insets(0, 10, 0, 0));
 
+        items.setPadding(new Insets(8, 10, 8, 10));
+        items.setStyle("-fx-background-insets: 5 0 5 0;");
+        items.getStyleClass().add("ordered-items-container");
+        order.getItemList().stream()
+                .forEach(pair -> items.getChildren().add(
+                        constructItemLabel(pair.toString())));
+    }
+
+    public void setOrderStatusStyle() {
         if (order.getPaidStatus()) {
             paidStatus.setText("Paid");
             paidStatus.setStyle("-fx-background-color: #D9DCFF; -fx-text-fill: #707BE3");
@@ -103,13 +116,12 @@ public class OrderCard extends UiPart<Region> {
             deliveryStatus.setStyle("-fx-background-color: #FF6C64; -fx-text-fill: #FFEDEC");
         }
 
-        items.setPadding(new Insets(8, 10, 8, 10));
-        items.setStyle("-fx-background-insets: 5 0 5 0;");
-        items.getStyleClass().add("ordered-items-container");
-        order.getItemList().stream()
-                .forEach(pair -> items.getChildren().add(
-                        constructItemLabel(pair.toString())));
-
+        if (order.isCompleted()) {
+            paidStatus.setText("Completed");
+            paidStatus.setStyle("-fx-background-color: #DFDFEB; -fx-text-fill: #7A7CA5");
+            deliveryStatus.setText(null);
+            deliveryStatus.setStyle("-fx-background-color: #7A7CA5");
+        }
     }
 
     /**

--- a/src/main/java/tracko/ui/OrderListPanel.java
+++ b/src/main/java/tracko/ui/OrderListPanel.java
@@ -26,10 +26,7 @@ public class OrderListPanel extends UiPart<Region> {
     public OrderListPanel(ObservableList<Order> orderList) {
         super(FXML);
         orderListView.setItems(orderList);
-        orderListView.setCellFactory(listView -> new OrderListViewCell() {{
-                setStyle("-fx-background-insets: 3px;");
-            }
-        });
+        orderListView.setCellFactory(listView -> new OrderListViewCell());
     }
 
     /**
@@ -44,6 +41,11 @@ public class OrderListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
+                if (!order.isCompleted()) {
+                    this.setStyle("-fx-background-color: #707BE3; -fx-background-insets: 3px;");
+                } else {
+                    this.setStyle("-fx-background-color: #777BB5; -fx-background-insets: 3px;");
+                }
                 setGraphic(new OrderCard(order, getIndex() + 1).getRoot());
             }
         }

--- a/src/main/resources/view/ItemListCard.fxml
+++ b/src/main/resources/view/ItemListCard.fxml
@@ -33,18 +33,16 @@
                         <Insets left="1"/>
                     </padding>
                 </HBox>
-                <VBox style="-fx-padding: 0 20 0 20;" spacing="2">
+                <VBox style="-fx-padding: 0 20 0 20;" spacing="2" HBox.hgrow="ALWAYS">
                     <VBox spacing="2">
                         <Label fx:id="itemName" text="\$first" styleClass="cell_big_label_item" />
-                        <HBox spacing="2">
-                            <HBox styleClass="light-green-container" alignment="CENTER" spacing="5.0">
-                                <Region styleClass="sellPrice-icon" id="sellPriceIcon"/>
-                                <Label fx:id="sellPrice" text="\$sellPrice" wrapText="true"/>
-                            </HBox>
-                            <HBox styleClass="costPrice-container" alignment="CENTER" spacing="5.0">
-                                <Region styleClass="costPrice-icon" id="costPriceIcon"/>
-                                <Label fx:id="costPrice" text="\$costPrice" wrapText="true"/>
-                            </HBox>
+                        <HBox styleClass="light-green-container" alignment="CENTER_LEFT" spacing="5.0">
+                            <Region styleClass="sellPrice-icon" id="sellPriceIcon"/>
+                            <Label fx:id="sellPrice" text="\$sellPrice" wrapText="true"/>
+                        </HBox>
+                        <HBox styleClass="costPrice-container" alignment="CENTER_LEFT" spacing="5.0">
+                            <Region styleClass="costPrice-icon" id="costPriceIcon"/>
+                            <Label fx:id="costPrice" text="\$costPrice" wrapText="true"/>
                         </HBox>
                         <HBox fx:id="quantityRow" alignment="CENTER" styleClass="quantity-row" spacing="5.0">
                             <Region styleClass="quantity-icon" id="quantityIcon"/>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -47,7 +47,9 @@
               <Insets top="55.0"/>
             </padding>
             <VBox id="resultPadding" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-              <StackPane fx:id="resultDisplayPlaceholder" minHeight="100" prefHeight="100" minWidth="550" prefWidth="550" maxWidth="550" styleClass="pane-with-border" VBox.vgrow="ALWAYS" HBox.hgrow="NEVER"/>
+              <StackPane fx:id="resultDisplayPlaceholder" minHeight="100" prefHeight="100" minWidth="450"
+                         prefWidth="450" maxWidth="450" styleClass="pane-with-border" VBox.vgrow="ALWAYS"
+                         HBox.hgrow="NEVER"/>
             </VBox>
 
             <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER" HBox.hgrow="NEVER">

--- a/src/main/resources/view/OrderListCard.fxml
+++ b/src/main/resources/view/OrderListCard.fxml
@@ -34,12 +34,13 @@
         </HBox>
         <VBox style="-fx-padding: 0 20 0 20;" spacing="2" HBox.hgrow="ALWAYS">
           <VBox fx:id="items" spacing="2"/>
-          <HBox alignment="CENTER_LEFT" spacing="5.0" styleClass="date-container">
-            <Region styleClass="date-icon" id="timeCreatedIcon"/>
+          <HBox alignment="CENTER_LEFT" spacing="5.0" fx:id="dateContainer" styleClass="date-container">
+            <Region styleClass="date-icon" fx:id="timeCreatedIcon"/>
             <Label fx:id="timeCreated" styleClass="date-label" text="\$timeCreated" />
           </HBox>
-          <HBox alignment="CENTER_LEFT" spacing="5.0" styleClass="light-green-container">
-            <Region styleClass="total-price-icon" id="totalPriceIcon"/>
+          <HBox fx:id="totalOrderPriceContainer" alignment="CENTER_LEFT"
+                spacing="5.0" styleClass="light-green-container">
+            <Region styleClass="total-price-icon" fx:id="totalPriceIcon"/>
             <Label fx:id="totalOrderPrice"/>
           </HBox>
           <HBox>

--- a/src/main/resources/view/TrackOTheme.css
+++ b/src/main/resources/view/TrackOTheme.css
@@ -604,7 +604,6 @@
 }
 
 #orderListView .list-cell:filled {
-    -fx-background-color: #707BE3;
     -fx-background-radius: 15px;
     -fx-background-insets: 0;
 }


### PR DESCRIPTION
# Final changes made: 
- Completed orders have a different color, opted for a less saturated color scheme instead to still match the theme of the application

https://user-images.githubusercontent.com/97304787/198328262-d7d56ead-08b6-4fd8-a227-1debe4c1610f.mov

- Fixed error of price overflow and changed selling price and cost price to be in two different lines.
- Fixed bug where `edito` can still edit orders

# Finalized UI
<img width="1792" alt="Screen Shot 2022-10-27 at 23 13 00" src="https://user-images.githubusercontent.com/97304787/198328812-9f81368f-8ab8-415d-8fbc-36180b650154.png">

## Do let me know if the colors are too desaturated!
Because after 1.3 we are no longer allowed to update the UI :D