### PR TITLE
Implement clear command

### DIFF
--- a/src/main/java/tracko/logic/commands/ClearCommand.java
+++ b/src/main/java/tracko/logic/commands/ClearCommand.java
@@ -14,7 +14,7 @@ public class ClearCommand extends MultiLevelCommand {
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "TrackO has been cleared!";
     public static final String CLEAR_CONFIRMATION_MESSAGE = "This command will clear all data stored in TrackO.\n"
-            + "Please enter 'done' to confirm deletion of all data stored in TrackO.\n"
+            + "Please enter 'confirm' to confirm deletion of all data stored in TrackO.\n"
             + "Otherwise, enter 'cancel' to abort clearing your data.";
     static final String MESSAGE_COMMAND_ABORTED = "Clear TrackO command aborted";
 

--- a/src/main/java/tracko/logic/commands/ClearCommand.java
+++ b/src/main/java/tracko/logic/commands/ClearCommand.java
@@ -3,7 +3,6 @@ package tracko.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import tracko.logic.commands.exceptions.CommandException;
-import tracko.logic.parser.exceptions.ParseException;
 import tracko.model.Model;
 import tracko.model.TrackO;
 
@@ -27,8 +26,6 @@ public class ClearCommand extends MultiLevelCommand {
         if (this.isCancelled) {
             // User has cancelled the command
             return new CommandResult(MESSAGE_COMMAND_ABORTED);
-        } else {
-
         }
 
         if (!this.isAwaitingInput()) {
@@ -38,16 +35,5 @@ public class ClearCommand extends MultiLevelCommand {
 
         return new CommandResult(CLEAR_CONFIRMATION_MESSAGE);
 
-    }
-
-    private ClearCommand parseAndUpdate(String args, ClearCommand command) throws ParseException {
-        if (args.equals("done")) {
-            command.setAwaitingInput(false);
-        } else if (args.equals("cancel")) {
-            command.setAwaitingInput(false);
-            command.cancel();
-        }
-
-        return command;
     }
 }

--- a/src/main/java/tracko/logic/parser/ClearCommandParser.java
+++ b/src/main/java/tracko/logic/parser/ClearCommandParser.java
@@ -1,0 +1,35 @@
+package tracko.logic.parser;
+
+import tracko.logic.commands.ClearCommand;
+import tracko.logic.parser.exceptions.ParseException;
+
+public class ClearCommandParser implements Parser<ClearCommand> {
+    public static final String INCORRECT_USER_INPUT_FORMAT = "Please enter 'done' to confirm removal of all data. " +
+            "Enter 'cancel' to abort clearing data. ";
+
+    @Override
+    public ClearCommand parse(String userInput) throws ParseException {
+        return new ClearCommand();
+    }
+
+    /**
+     * Parses the given {@code String} of confirmation argument for the given ClearCommand that is awaiting
+     * further input of user confirmation.
+     * @param args The user input
+     * @param command The given ClearCommand
+     * @return The updated command.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ClearCommand parseAndUpdate(String args, ClearCommand command) throws ParseException {
+        if (args.equals("done")) {
+            command.setAwaitingInput(false);
+            return command;
+        } else if (args.equals("cancel")) {
+            command.setAwaitingInput(false);
+            command.cancel();
+            return command;
+        } else {
+            throw new ParseException(INCORRECT_USER_INPUT_FORMAT);
+        }
+    }
+}

--- a/src/main/java/tracko/logic/parser/ClearCommandParser.java
+++ b/src/main/java/tracko/logic/parser/ClearCommandParser.java
@@ -7,7 +7,7 @@ import tracko.logic.parser.exceptions.ParseException;
  * Parses confirmation input from user to allow MultiLevelCommand implementation of the ClearCommand class
  */
 public class ClearCommandParser implements Parser<ClearCommand> {
-    public static final String INCORRECT_USER_INPUT_FORMAT = "Please enter 'done' to confirm removal of all data. "
+    public static final String INCORRECT_USER_INPUT_FORMAT = "Please enter 'confirm' to confirm removal of all data. "
             + "Enter 'cancel' to abort clearing data. ";
 
     @Override
@@ -24,7 +24,7 @@ public class ClearCommandParser implements Parser<ClearCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ClearCommand parseAndUpdate(String args, ClearCommand command) throws ParseException {
-        if (args.equals("done")) {
+        if (args.equals("confirm")) {
             command.setAwaitingInput(false);
             return command;
         } else if (args.equals("cancel")) {

--- a/src/main/java/tracko/logic/parser/ClearCommandParser.java
+++ b/src/main/java/tracko/logic/parser/ClearCommandParser.java
@@ -3,9 +3,12 @@ package tracko.logic.parser;
 import tracko.logic.commands.ClearCommand;
 import tracko.logic.parser.exceptions.ParseException;
 
+/**
+ * Parses confirmation input from user to allow MultiLevelCommand implementation of the ClearCommand class
+ */
 public class ClearCommandParser implements Parser<ClearCommand> {
-    public static final String INCORRECT_USER_INPUT_FORMAT = "Please enter 'done' to confirm removal of all data. " +
-            "Enter 'cancel' to abort clearing data. ";
+    public static final String INCORRECT_USER_INPUT_FORMAT = "Please enter 'done' to confirm removal of all data. "
+            + "Enter 'cancel' to abort clearing data. ";
 
     @Override
     public ClearCommand parse(String userInput) throws ParseException {

--- a/src/main/java/tracko/logic/parser/TrackOParser.java
+++ b/src/main/java/tracko/logic/parser/TrackOParser.java
@@ -56,6 +56,8 @@ public class TrackOParser {
     public MultiLevelCommand parseAndUpdateCommand(String userInput, MultiLevelCommand command) throws ParseException {
         if (command instanceof AddOrderCommand) {
             return new AddOrderCommandParser().parseAndUpdate(userInput, (AddOrderCommand) command);
+        } else if (command instanceof ClearCommand) {
+            return new ClearCommandParser().parseAndUpdate(userInput, (ClearCommand) command);
         }
         throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
     }
@@ -119,7 +121,9 @@ public class TrackOParser {
             return new EditItemCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            // an empty string is used as a dummy input for the parser method.
+            // no inputs from the user is taken in as arguments for the ClearCommand method
+            return new ClearCommandParser().parse("");
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/tracko/ui/ItemCard.java
+++ b/src/main/java/tracko/ui/ItemCard.java
@@ -73,12 +73,10 @@ public class ItemCard extends UiPart<Region> {
         sellPrice.setText("$" + inventoryItem.getSellPrice().toString());
         sellPrice.setWrapText(true);
         sellPrice.setPadding(new Insets(0, 10, 0, 0));
-        //sellPrice.setMinWidth(150);
 
         costPrice.setText("$" + inventoryItem.getCostPrice().toString());
         costPrice.setWrapText(true);
         costPrice.setPadding(new Insets(0, 10, 0, 0));
-        //costPrice.setMinWidth(150);
 
         inventoryItem.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/tracko/ui/ItemCard.java
+++ b/src/main/java/tracko/ui/ItemCard.java
@@ -73,12 +73,12 @@ public class ItemCard extends UiPart<Region> {
         sellPrice.setText("$" + inventoryItem.getSellPrice().toString());
         sellPrice.setWrapText(true);
         sellPrice.setPadding(new Insets(0, 10, 0, 0));
-        sellPrice.setMinWidth(150);
+        //sellPrice.setMinWidth(150);
 
         costPrice.setText("$" + inventoryItem.getCostPrice().toString());
         costPrice.setWrapText(true);
         costPrice.setPadding(new Insets(0, 10, 0, 0));
-        costPrice.setMinWidth(150);
+        //costPrice.setMinWidth(150);
 
         inventoryItem.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))


### PR DESCRIPTION
The `clear` command allows the user to delete all data in both the existing `OrderList` and the `InventoryList` in TrackO. The clear command uses the command word `clear` without taking in any user inputs after the command word. 

After user inputs the `clear` command, user will be prompted by a confirmation message to either

- confirm their decision to clear all data in TrackO with the keyword `done`
- abort the clear command with the keyword `cancel`

The `ClearCommand` class extends `MultiLevelCommand` to enable waiting of user confirmation. 

UGs and DGs will be update in a separate PR. Due to time constraints, test cases will be written in week 12