### PR TITLE
Disallow editing of items with ongoing orders

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -108,6 +108,7 @@ Format: `deletei INDEX`
 * Deletes the item at the specified `INDEX`.
 * The index refers to the index number shown in the displayed inventory list.
 * The index **must be a positive integer** 1, 2, 3, …​
+* Deleting items with active orders is not permitted.
 
 Examples:
 * `listi` followed by `deletei 2` deletes the 2nd item in the list of tracked inventory.
@@ -124,6 +125,7 @@ Format: `editi INDEX [i/ITEM_NAME] [q/QUANTITY] [d/DESCRIPTION] [t/TAG]…​ [s
 * The index **must be a positive integer** 1, 2, 3, …​
 * You can remove all the item’s tags by typing `t/` without
   specifying any tags after it.
+* Editing items with active orders is not permitted.
 
 Examples:
 * `editi 1 i/Table q/200 d/Metal Table t/Fragile`

--- a/src/main/java/tracko/logic/commands/item/DeleteItemCommand.java
+++ b/src/main/java/tracko/logic/commands/item/DeleteItemCommand.java
@@ -10,7 +10,7 @@ import tracko.logic.commands.CommandResult;
 import tracko.logic.commands.exceptions.CommandException;
 import tracko.model.Model;
 import tracko.model.item.InventoryItem;
-import tracko.model.item.exceptions.ItemUndeletableException;
+import tracko.model.item.exceptions.ItemUnmodifiableException;
 
 /**
  * Deletes an item identified using it's displayed index in TrackO.
@@ -49,7 +49,7 @@ public class DeleteItemCommand extends Command {
         try {
             model.deleteItem(inventoryItemToDelete);
             return new CommandResult(String.format(MESSAGE_DELETE_ITEM_SUCCESS, inventoryItemToDelete));
-        } catch (ItemUndeletableException e) {
+        } catch (ItemUnmodifiableException e) {
             return new CommandResult(String.format(MESSAGE_UNCOMPLETED_ORDER_ITEM, inventoryItemToDelete));
         }
     }

--- a/src/main/java/tracko/logic/commands/item/EditItemCommand.java
+++ b/src/main/java/tracko/logic/commands/item/EditItemCommand.java
@@ -21,6 +21,7 @@ import tracko.model.item.InventoryItem;
 import tracko.model.item.ItemName;
 import tracko.model.item.Price;
 import tracko.model.item.Quantity;
+import tracko.model.item.exceptions.ItemUndeletableException;
 import tracko.model.tag.Tag;
 
 /**
@@ -53,6 +54,8 @@ public class EditItemCommand extends Command {
 
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the inventory list.";
+    public static final String MESSAGE_UNCOMPLETED_ORDER_ITEM = "Item cannot be edited, there exists uncompleted "
+            + "orders for item:\n%1$s";
 
     private final Index index;
     private final EditItemDescriptor editItemDescriptor;
@@ -85,10 +88,14 @@ public class EditItemCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_ITEM);
         }
 
-        model.setItem(inventoryItemToEdit, editedInventoryItem);
-        model.refreshData();
-        model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
-        return new CommandResult(String.format(MESSAGE_EDIT_ITEM_SUCCESS, editedInventoryItem));
+        try {
+            model.setItem(inventoryItemToEdit, editedInventoryItem);
+            model.refreshData();
+            model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
+            return new CommandResult(String.format(MESSAGE_EDIT_ITEM_SUCCESS, editedInventoryItem));
+        } catch (ItemUndeletableException e) {
+            return new CommandResult(String.format(MESSAGE_UNCOMPLETED_ORDER_ITEM, editedInventoryItem));
+        }
     }
 
     /**

--- a/src/main/java/tracko/logic/commands/item/EditItemCommand.java
+++ b/src/main/java/tracko/logic/commands/item/EditItemCommand.java
@@ -21,7 +21,7 @@ import tracko.model.item.InventoryItem;
 import tracko.model.item.ItemName;
 import tracko.model.item.Price;
 import tracko.model.item.Quantity;
-import tracko.model.item.exceptions.ItemUndeletableException;
+import tracko.model.item.exceptions.ItemUnmodifiableException;
 import tracko.model.tag.Tag;
 
 /**
@@ -93,7 +93,7 @@ public class EditItemCommand extends Command {
             model.refreshData();
             model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
             return new CommandResult(String.format(MESSAGE_EDIT_ITEM_SUCCESS, editedInventoryItem));
-        } catch (ItemUndeletableException e) {
+        } catch (ItemUnmodifiableException e) {
             return new CommandResult(String.format(MESSAGE_UNCOMPLETED_ORDER_ITEM, editedInventoryItem));
         }
     }

--- a/src/main/java/tracko/model/TrackO.java
+++ b/src/main/java/tracko/model/TrackO.java
@@ -7,7 +7,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import tracko.model.item.InventoryItem;
 import tracko.model.item.InventoryList;
-import tracko.model.item.exceptions.ItemUndeletableException;
+import tracko.model.item.exceptions.ItemUnmodifiableException;
 import tracko.model.order.Order;
 import tracko.model.order.OrderList;
 
@@ -130,7 +130,7 @@ public class TrackO implements ReadOnlyTrackO {
      */
     public void deleteItem(InventoryItem inventoryItem) {
         if (orders.containsOrderWithItem(inventoryItem)) {
-            throw new ItemUndeletableException();
+            throw new ItemUnmodifiableException();
         }
         items.delete(inventoryItem);
     }
@@ -151,7 +151,7 @@ public class TrackO implements ReadOnlyTrackO {
     public void setItem(InventoryItem target, InventoryItem editedInventoryItem) {
         requireNonNull(editedInventoryItem);
         if (orders.containsOrderWithItem(target)) {
-            throw new ItemUndeletableException();
+            throw new ItemUnmodifiableException();
         }
         items.setItem(target, editedInventoryItem);
     }

--- a/src/main/java/tracko/model/TrackO.java
+++ b/src/main/java/tracko/model/TrackO.java
@@ -150,6 +150,9 @@ public class TrackO implements ReadOnlyTrackO {
      */
     public void setItem(InventoryItem target, InventoryItem editedInventoryItem) {
         requireNonNull(editedInventoryItem);
+        if (orders.containsOrderWithItem(target)) {
+            throw new ItemUndeletableException();
+        }
         items.setItem(target, editedInventoryItem);
     }
 

--- a/src/main/java/tracko/model/item/exceptions/ItemUnmodifiableException.java
+++ b/src/main/java/tracko/model/item/exceptions/ItemUnmodifiableException.java
@@ -3,5 +3,5 @@ package tracko.model.item.exceptions;
 /**
  * Signals that the operation is trying to remove an undeletable item
  */
-public class ItemUndeletableException extends RuntimeException {
+public class ItemUnmodifiableException extends RuntimeException {
 }

--- a/src/test/java/tracko/logic/commands/item/EditItemCommandTest.java
+++ b/src/test/java/tracko/logic/commands/item/EditItemCommandTest.java
@@ -12,7 +12,7 @@ import static tracko.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static tracko.logic.commands.CommandTestUtil.showItemAtIndex;
 import static tracko.testutil.TypicalIndexes.INDEX_FIRST;
 import static tracko.testutil.TypicalIndexes.INDEX_SECOND;
-import static tracko.testutil.TypicalOrders.getTrackOWithTypicalOrders;
+import static tracko.testutil.TypicalItems.getTrackOWithTypicalItems;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,21 +29,18 @@ import tracko.testutil.EditItemDescriptorBuilder;
 import tracko.testutil.InventoryItemBuilder;
 
 class EditItemCommandTest {
-    private Model model = new ModelManager(getTrackOWithTypicalOrders(), new UserPrefs());
+    private Model model = new ModelManager(getTrackOWithTypicalItems(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastItem = Index.fromOneBased(model.getFilteredItemList().size());
-        InventoryItem lastItem = model.getFilteredItemList().get(indexLastItem.getZeroBased());
-
-        InventoryItem editedItem = new InventoryItemBuilder(lastItem).build();
+        InventoryItem editedItem = new InventoryItemBuilder().build();
         EditItemDescriptor descriptor = new EditItemDescriptorBuilder(editedItem).build();
-        EditItemCommand editItemCommand = new EditItemCommand(indexLastItem, descriptor);
+        EditItemCommand editItemCommand = new EditItemCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditItemCommand.MESSAGE_EDIT_ITEM_SUCCESS, editedItem);
 
         Model expectedModel = new ModelManager(new TrackO(model.getTrackO()), new UserPrefs());
-        expectedModel.setItem(model.getFilteredItemList().get(indexLastItem.getZeroBased()), editedItem);
+        expectedModel.setItem(model.getFilteredItemList().get(0), editedItem);
 
         assertCommandSuccess(editItemCommand, model, expectedMessage, expectedModel);
     }
@@ -72,10 +69,8 @@ class EditItemCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        Index indexLastItem = Index.fromOneBased(model.getFilteredItemList().size());
-
-        EditItemCommand editItemCommand = new EditItemCommand(indexLastItem, new EditItemDescriptor());
-        InventoryItem editedItem = model.getFilteredItemList().get(indexLastItem.getZeroBased());
+        EditItemCommand editItemCommand = new EditItemCommand(INDEX_FIRST, new EditItemDescriptor());
+        InventoryItem editedItem = model.getFilteredItemList().get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditItemCommand.MESSAGE_EDIT_ITEM_SUCCESS, editedItem);
 

--- a/src/test/java/tracko/logic/commands/item/EditItemCommandTest.java
+++ b/src/test/java/tracko/logic/commands/item/EditItemCommandTest.java
@@ -33,14 +33,17 @@ class EditItemCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        InventoryItem editedItem = new InventoryItemBuilder().build();
+        Index indexLastItem = Index.fromOneBased(model.getFilteredItemList().size());
+        InventoryItem lastItem = model.getFilteredItemList().get(indexLastItem.getZeroBased());
+
+        InventoryItem editedItem = new InventoryItemBuilder(lastItem).build();
         EditItemDescriptor descriptor = new EditItemDescriptorBuilder(editedItem).build();
-        EditItemCommand editItemCommand = new EditItemCommand(INDEX_FIRST, descriptor);
+        EditItemCommand editItemCommand = new EditItemCommand(indexLastItem, descriptor);
 
         String expectedMessage = String.format(EditItemCommand.MESSAGE_EDIT_ITEM_SUCCESS, editedItem);
 
         Model expectedModel = new ModelManager(new TrackO(model.getTrackO()), new UserPrefs());
-        expectedModel.setItem(model.getFilteredItemList().get(0), editedItem);
+        expectedModel.setItem(model.getFilteredItemList().get(indexLastItem.getZeroBased()), editedItem);
 
         assertCommandSuccess(editItemCommand, model, expectedMessage, expectedModel);
     }
@@ -69,8 +72,10 @@ class EditItemCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditItemCommand editItemCommand = new EditItemCommand(INDEX_FIRST, new EditItemDescriptor());
-        InventoryItem editedItem = model.getFilteredItemList().get(INDEX_FIRST.getZeroBased());
+        Index indexLastItem = Index.fromOneBased(model.getFilteredItemList().size());
+
+        EditItemCommand editItemCommand = new EditItemCommand(indexLastItem, new EditItemDescriptor());
+        InventoryItem editedItem = model.getFilteredItemList().get(indexLastItem.getZeroBased());
 
         String expectedMessage = String.format(EditItemCommand.MESSAGE_EDIT_ITEM_SUCCESS, editedItem);
 

--- a/src/test/java/tracko/testutil/OrderBuilder.java
+++ b/src/test/java/tracko/testutil/OrderBuilder.java
@@ -5,6 +5,7 @@ import static tracko.testutil.TypicalItems.INVENTORY_ITEM_1;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import tracko.model.item.InventoryItem;
 import tracko.model.item.Quantity;
@@ -122,6 +123,16 @@ public class OrderBuilder {
      */
     public OrderBuilder withItemList(List<ItemQuantityPair> itemList) {
         this.itemList = itemList;
+        return this;
+    }
+
+    /**
+     * Sets the list of ordered items of the {@code Order} that we are building.
+     */
+    public OrderBuilder withRecordedItemList(List<ItemQuantityPair> itemList) {
+        List<ItemQuantityPair> recordedItems = this.itemList.stream()
+                .map(ItemQuantityPair::getImmutableItemCopy).collect(Collectors.toList());
+        this.itemList = recordedItems;
         return this;
     }
 

--- a/src/test/java/tracko/testutil/OrderBuilder.java
+++ b/src/test/java/tracko/testutil/OrderBuilder.java
@@ -94,7 +94,7 @@ public class OrderBuilder {
     }
 
     /**
-     * Sets the {@code LocalDateTime} of the {@code Order} that we are building.
+     * Sets the {@code timeCreated} of the {@code Order} that we are building.
      */
     public OrderBuilder withTimeCreated(LocalDateTime timeCreated) {
         this.timeCreated = timeCreated;
@@ -102,7 +102,7 @@ public class OrderBuilder {
     }
 
     /**
-     * Sets the default {@code LocalDateTime} of the {@code Order} that we are building.
+     * Sets the default {@code timeCreated} of the {@code Order} that we are building.
      */
     public OrderBuilder withDefaultTimeCreated() {
         this.timeCreated = DEFAULT_TIME_CREATED;
@@ -130,6 +130,22 @@ public class OrderBuilder {
      */
     public OrderBuilder withItemQuantityPair(ItemQuantityPair itemQuantityPair) {
         itemList.add(itemQuantityPair);
+        return this;
+    }
+
+    /**
+     * Sets the {@code isPaid} status of the {@code Order} that we are building.
+     */
+    public OrderBuilder withPaidStatus(Boolean status) {
+        this.isPaid = status;
+        return this;
+    }
+
+    /**
+     * Sets the {@code isDelivered} status of the {@code Order} that we are building.
+     */
+    public OrderBuilder withDeliveredStatus(Boolean status) {
+        this.isDelivered = status;
         return this;
     }
 

--- a/src/test/java/tracko/testutil/TypicalItems.java
+++ b/src/test/java/tracko/testutil/TypicalItems.java
@@ -80,7 +80,8 @@ public class TypicalItems {
 
     public static List<InventoryItem> getTypicalItems() {
         return new ArrayList<>(Arrays.asList(DEFAULT_INVENTORY_ITEM, INVENTORY_ITEM_1, INVENTORY_ITEM_2,
-            INVENTORY_ITEM_3, INVENTORY_ITEM_4, INVENTORY_ITEM_5, INVENTORY_ITEM_6, INVENTORY_ITEM_7));
+            INVENTORY_ITEM_3, INVENTORY_ITEM_4, INVENTORY_ITEM_5, INVENTORY_ITEM_6
+                , INVENTORY_ITEM_7, INVENTORY_ITEM_8));
     }
 
     /**

--- a/src/test/java/tracko/testutil/TypicalItems.java
+++ b/src/test/java/tracko/testutil/TypicalItems.java
@@ -44,12 +44,12 @@ public class TypicalItems {
             .withQuantity(48).withDescription("Cute shark slippers")
             .withSellPrice(10.00)
             .withCostPrice(2.00).build();
+
+    // Manually added
     public static final InventoryItem INVENTORY_ITEM_8 = new InventoryItemBuilder().withItemName("Keychain")
             .withQuantity(95).withDescription("Small copper keychain")
             .withSellPrice(0.50)
             .withCostPrice(4.99).build();
-
-    // Manually added
     public static final InventoryItem INVENTORY_ITEM_9 = new InventoryItemBuilder().withItemName("Mechanical Pencil")
             .withQuantity(278).withDescription("Mechanical pencil with rubber grip")
             .withSellPrice(0.30)
@@ -80,8 +80,7 @@ public class TypicalItems {
 
     public static List<InventoryItem> getTypicalItems() {
         return new ArrayList<>(Arrays.asList(DEFAULT_INVENTORY_ITEM, INVENTORY_ITEM_1, INVENTORY_ITEM_2,
-            INVENTORY_ITEM_3, INVENTORY_ITEM_4, INVENTORY_ITEM_5, INVENTORY_ITEM_6,
-                INVENTORY_ITEM_7, INVENTORY_ITEM_8));
+            INVENTORY_ITEM_3, INVENTORY_ITEM_4, INVENTORY_ITEM_5, INVENTORY_ITEM_6, INVENTORY_ITEM_7));
     }
 
     /**

--- a/src/test/java/tracko/testutil/TypicalItems.java
+++ b/src/test/java/tracko/testutil/TypicalItems.java
@@ -44,12 +44,12 @@ public class TypicalItems {
             .withQuantity(48).withDescription("Cute shark slippers")
             .withSellPrice(10.00)
             .withCostPrice(2.00).build();
-
-    // Manually added
     public static final InventoryItem INVENTORY_ITEM_8 = new InventoryItemBuilder().withItemName("Keychain")
             .withQuantity(95).withDescription("Small copper keychain")
             .withSellPrice(0.50)
             .withCostPrice(4.99).build();
+
+    // Manually added
     public static final InventoryItem INVENTORY_ITEM_9 = new InventoryItemBuilder().withItemName("Mechanical Pencil")
             .withQuantity(278).withDescription("Mechanical pencil with rubber grip")
             .withSellPrice(0.30)

--- a/src/test/java/tracko/testutil/TypicalItems.java
+++ b/src/test/java/tracko/testutil/TypicalItems.java
@@ -80,8 +80,8 @@ public class TypicalItems {
 
     public static List<InventoryItem> getTypicalItems() {
         return new ArrayList<>(Arrays.asList(DEFAULT_INVENTORY_ITEM, INVENTORY_ITEM_1, INVENTORY_ITEM_2,
-            INVENTORY_ITEM_3, INVENTORY_ITEM_4, INVENTORY_ITEM_5, INVENTORY_ITEM_6
-                , INVENTORY_ITEM_7, INVENTORY_ITEM_8));
+            INVENTORY_ITEM_3, INVENTORY_ITEM_4, INVENTORY_ITEM_5, INVENTORY_ITEM_6,
+                INVENTORY_ITEM_7, INVENTORY_ITEM_8));
     }
 
     /**


### PR DESCRIPTION
I have included the UG update for `deletei` in this PR as well as it's only 1 line.

### Changes
---
- Updated the `EditItemCommand` to only permit editing of items with no active orders.
- Updated UG for `deletei` and `editi`
- Fix EditItemCommandTest
- Added some new methods to OrderBuilder but did not end up using them