### PR TITLE
Fix UI tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -69,7 +69,7 @@ Adds an item to the list of tracked inventory.
 Format: `addi n/ITEM_NAME q/QUANTITY d/DESCRIPTION [t/TAG]…​ sp/SELL_PRICE cp/COST_PRICE`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-An inventory item can have any number of tags (including 0)
+An inventory item can have any number of tags (including 0). A tag **cannot** have more than 30 characters.
 </div>
 
 Examples:

--- a/src/main/java/tracko/model/tag/Tag.java
+++ b/src/main/java/tracko/model/tag/Tag.java
@@ -9,7 +9,8 @@ import static tracko.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and "
+            + "should not be more than 30 characters long.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;
@@ -29,7 +30,7 @@ public class Tag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && (test.length() <= 30);
     }
 
     @Override

--- a/src/main/java/tracko/model/tag/Tag.java
+++ b/src/main/java/tracko/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static tracko.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and "
+    public static final String MESSAGE_CONSTRAINTS = "A tag's name should be alphanumeric and "
             + "should not be more than 30 characters long.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 

--- a/src/main/java/tracko/ui/ItemCard.java
+++ b/src/main/java/tracko/ui/ItemCard.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.text.TextAlignment;
@@ -45,7 +46,7 @@ public class ItemCard extends UiPart<Region> {
     @FXML
     private Label costPrice;
     @FXML
-    private HBox tags;
+    private FlowPane tags;
 
     /**
      * Creates a {@code ItemCode} with the given {@code Item} and index to display.
@@ -92,7 +93,12 @@ public class ItemCard extends UiPart<Region> {
      */
     public Label constructTags(String tagName) {
         Label tagLabel = new Label();
-        tagLabel.setText(tagName);
+        String shortenedTag = tagName;
+        tagLabel.setMaxWidth(300);
+//        if (shortenedTag.length() >= 30) {
+//            shortenedTag = tagName.substring(0, 29);
+//        }
+        tagLabel.setText(shortenedTag);
         tagLabel.setWrapText(true);
         return tagLabel;
     }

--- a/src/main/java/tracko/ui/ItemCard.java
+++ b/src/main/java/tracko/ui/ItemCard.java
@@ -93,12 +93,8 @@ public class ItemCard extends UiPart<Region> {
      */
     public Label constructTags(String tagName) {
         Label tagLabel = new Label();
-        String shortenedTag = tagName;
         tagLabel.setMaxWidth(300);
-//        if (shortenedTag.length() >= 30) {
-//            shortenedTag = tagName.substring(0, 29);
-//        }
-        tagLabel.setText(shortenedTag);
+        tagLabel.setText(tagName);
         tagLabel.setWrapText(true);
         return tagLabel;
     }

--- a/src/main/resources/view/ItemListCard.fxml
+++ b/src/main/resources/view/ItemListCard.fxml
@@ -52,7 +52,9 @@
                     <VBox id="descriptionBox">
                         <Label fx:id="description" styleClass="cell_small_label_item" text="\$description" />
                     </VBox>
-                    <HBox fx:id="tags" spacing="5.0"/>
+                    <HBox HBox.hgrow="ALWAYS">
+                    <FlowPane fx:id="tags"/>
+                    </HBox>
                 </VBox>
             </HBox>
         </VBox>


### PR DESCRIPTION
In this PR: 
- Tags are now limited to 30 characters. If the user inputs more than that, an error will be thrown
- `HBox` for tags is changed back to `FlowPane`.  Previously when suggesting the change, I was not aware that the `HBox` only lays its children in a single row, which is why it condensed everything to a vertical line when it does not fit. I also tried finding ways to set boundaries to the `FlowPane`, because apparently its behavior allows its children to overflow, however I could not find any way to do that. Limiting the tags' characters makes sure that the text will not overflow out of the box if it is too long.

<img width="1792" alt="Screen Shot 2022-11-01 at 00 44 33" src="https://user-images.githubusercontent.com/97304787/199062423-9f900cae-23cd-4983-ac7d-2bb05258c4d2.png">

<img width="1792" alt="Screen Shot 2022-11-01 at 00 45 08" src="https://user-images.githubusercontent.com/97304787/199062524-6afd8386-95a5-419c-ad1a-35e17c468de9.png">
