### PR TITLE
Fix extra order panels

### DIFF
--- a/src/main/java/tracko/ui/OrderListPanel.java
+++ b/src/main/java/tracko/ui/OrderListPanel.java
@@ -40,9 +40,10 @@ public class OrderListPanel extends UiPart<Region> {
             if (empty || order == null) {
                 setGraphic(null);
                 setText(null);
+                this.setStyle("-fx-background-color: #D9DCFF");
             } else {
                 if (!order.isCompleted()) {
-                    this.setStyle("-fx-background-color: #707BE3; -fx-background-insets: 3px;");
+                    this.setStyle(" -fx-background-insets: 3px;");
                 } else {
                     this.setStyle("-fx-background-color: #777BB5; -fx-background-insets: 3px;");
                 }

--- a/src/main/resources/view/TrackOTheme.css
+++ b/src/main/resources/view/TrackOTheme.css
@@ -604,6 +604,7 @@
 }
 
 #orderListView .list-cell:filled {
+    -fx-background-color: #707BE3;
     -fx-background-radius: 15px;
     -fx-background-insets: 0;
 }


### PR DESCRIPTION
# In this PR

I fixed the behavior of the order panels; this is caused by the order panels retaining the `background-color` property even after the cell is empty (i.e. `order == null` or `order` is `empty`, so an extra css line has been added to the `updateItem` method in the `OrderListViewCell` class.

## Deleting ongoing orders

https://user-images.githubusercontent.com/97304787/199068705-298ad2d3-8b17-4cde-9d19-3d32d0a3d5a9.mov

## Deleting completed orders

https://user-images.githubusercontent.com/97304787/199068715-f6d5662a-ce1c-4485-96fa-65f42663c327.mov


