### PR TITLE
Fix price parsing errors & context menu readability

### DIFF
--- a/src/main/java/tracko/logic/parser/ParserUtil.java
+++ b/src/main/java/tracko/logic/parser/ParserUtil.java
@@ -178,7 +178,13 @@ public class ParserUtil {
     public static Price parsePrice(String price) throws ParseException {
         requireNonNull(price);
         String trimmedPrice = price.trim();
-        Double doublePrice = Double.parseDouble(trimmedPrice);
+        Double doublePrice;
+
+        try {
+            doublePrice = Double.parseDouble(trimmedPrice);
+        } catch (NumberFormatException e) {
+            throw new ParseException(Price.MESSAGE_CONSTRAINTS);
+        }
 
         if (!(StringUtil.isNonNegativeUnsignedFloat(trimmedPrice)
                 && Price.isValidPrice(doublePrice))) {

--- a/src/main/java/tracko/model/item/Price.java
+++ b/src/main/java/tracko/model/item/Price.java
@@ -68,7 +68,7 @@ public class Price {
 
     @Override
     public String toString() {
-        return String.format("%.2f", value);
+        return "$" + String.format("%.2f", value);
     }
 
     @Override

--- a/src/main/java/tracko/model/item/Price.java
+++ b/src/main/java/tracko/model/item/Price.java
@@ -11,7 +11,7 @@ import java.math.RoundingMode;
  */
 public class Price {
     public static final String MESSAGE_CONSTRAINTS =
-            "Price should be non-negative and rounded to the nearest cent.";
+            "Price should be numeric, non-negative, and rounded to the nearest cent.";
 
     public final Double value;
 

--- a/src/main/java/tracko/model/item/Quantity.java
+++ b/src/main/java/tracko/model/item/Quantity.java
@@ -8,7 +8,8 @@ import static tracko.commons.util.CollectionUtil.requireAllNonNull;
  */
 public class Quantity {
     public static final String MESSAGE_CONSTRAINTS = "Quantity should be valid."
-            + "\nA valid Quantity value should be non-empty, non-negative, and should not exceed 2,147,483,647.";
+            + "\nA valid Quantity value should be numeric, non-empty, "
+            + "non-negative, and should not exceed 2,147,483,647.";
 
 
     public final Integer value;

--- a/src/main/java/tracko/ui/ItemCard.java
+++ b/src/main/java/tracko/ui/ItemCard.java
@@ -71,11 +71,11 @@ public class ItemCard extends UiPart<Region> {
         description.setTextAlignment(TextAlignment.JUSTIFY);
         description.setPadding(new Insets(0, 10, 0, 0));
 
-        sellPrice.setText("$" + inventoryItem.getSellPrice().toString());
+        sellPrice.setText(inventoryItem.getSellPrice().toString());
         sellPrice.setWrapText(true);
         sellPrice.setPadding(new Insets(0, 10, 0, 0));
 
-        costPrice.setText("$" + inventoryItem.getCostPrice().toString());
+        costPrice.setText(inventoryItem.getCostPrice().toString());
         costPrice.setWrapText(true);
         costPrice.setPadding(new Insets(0, 10, 0, 0));
 

--- a/src/main/resources/view/TrackOTheme.css
+++ b/src/main/resources/view/TrackOTheme.css
@@ -189,7 +189,7 @@
 }
 
 .context-menu .label {
-    -fx-text-fill: #3C3C3C;
+    -fx-text-fill: #FFFFFF;
 }
 
 .menu-bar {
@@ -209,10 +209,11 @@
     -fx-focus-color: #707BE3;
 }
 
-.context-menu:focused {
+.context-menu {
     -fx-background-color:#3C3C3C;
     -fx-focus-color:#3C3C3C;
 }
+
 .menu .left-container {
     -fx-background-color: #FFF2E7;
 }


### PR DESCRIPTION
# In this PR

1. Added that `Quantity` must be numeric

<img width="488" alt="Screen Shot 2022-11-01 at 14 01 39" src="https://user-images.githubusercontent.com/97304787/199169038-8e94886d-cc92-44e7-8839-3ebdb43b4553.png">

2. Tried replicating the commands in https://github.com/AY2223S1-CS2103T-W15-3/tp/issues/154 and the app is now responsive and displays an error message:
- After `addi i/Chairo q/one d/This is a wooden dining chair t/Furniture sp/50 cp/20`

<img width="475" alt="Screen Shot 2022-11-01 at 14 04 29" src="https://user-images.githubusercontent.com/97304787/199169387-dccb8309-5687-4225-8d83-fd042d1ce274.png">

- After `addi i/Chairo q/100 d/This is a wooden dining chair t/Furniture sp/one cp/20`

<img width="469" alt="Screen Shot 2022-11-01 at 14 05 25" src="https://user-images.githubusercontent.com/97304787/199169492-3bb7f777-ac61-43e4-b3f1-a9503acbed95.png">

#### Context menu readability

Apparently if you right click on the `ResultDisplay` and the `CommandBox`, a menu will appear where you can select all/copy/undo/etc. The one we had previously had some flaws: if the context menu is focused, the background will turn white, and because the text was also in a light color, it is not visible. Hence, I have changed it as such:

https://user-images.githubusercontent.com/97304787/199172318-60cd9b6d-e29a-4417-ab1c-1d6b7a7f1046.mov

