### PR TITLE
Fix PE-D bugs in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -295,7 +295,7 @@ Format: `marko INDEX [-p] [-d]`
 * When an order is completed (marked as both `paid` and `delivered`), 
 the colour of the particular order's card will be in a darker shade than an uncompleted order. 
 
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+<div markdown="span" class="alert alert-primary">:bulb: **Note:**
 You can mark an order with insufficient stock as paid (to record pre-payments) but you **cannot** 
 mark an order with **insufficient stock** as **delivered**. 
 </div>
@@ -307,7 +307,9 @@ Examples:
 
 ### Clearing all existing data in TrackO : `clear`
 
-Clears all data (in both `Order List` and `Inventory List`) from TrackO.
+If you want clear all sample data present, `clear` is the command for you. 
+
+The command `clear` clears all data (in both `Order List` and `Inventory List`) from TrackO.
 
 1. Initiate the command to clear all data from TrackO. <br>
     Format: `clear`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -49,7 +49,7 @@ TrackO is a **desktop app built for small business owners to help them manage or
   e.g. in `findo KEYWORD [MORE_KEYWORDS]`, only the first `KEYWORD` is compulsory. The rest are optional. 
 
 * Parameters can be in any order.<br>
-  e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
+  e.g. if the command specifies `i/ITEM_NAME q/QUANTITY`, `q/QUANTITY i/ITEM_NAME` is also acceptable.
 
 * All command keywords (e.g. `addo`, `marko`, `editi`, etc.), prefixes (e.g.`p/`, `i/`, etc.) 
 and flags(e.g. `-p`, `-D`, etc.) are **case-sensitive**. 
@@ -66,7 +66,7 @@ and flags(e.g. `-p`, `-D`, etc.) are **case-sensitive**.
 
 Adds an item to the list of tracked inventory.
 
-Format: `addi n/ITEM_NAME q/QUANTITY d/DESCRIPTION [t/TAG]…​ sp/SELL_PRICE cp/COST_PRICE`
+Format: `addi i/ITEM_NAME q/QUANTITY d/DESCRIPTION [t/TAG]…​ sp/SELL_PRICE cp/COST_PRICE`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 An inventory item's name must be more than 1 character long.
@@ -77,8 +77,8 @@ An inventory item can have any number of tags (including 0). A tag should only c
 </div>
 
 Examples:
-* `addi n/Keychain q/20 d/Silicone keychain with a metal buckle sp/3.50 cp/1`
-* `addi n/Chair q/10 d/This is a wooden dining chair t/Furniture sp/50 cp/20`
+* `addi i/Keychain q/20 d/Silicone keychain with a metal buckle sp/3.50 cp/1`
+* `addi i/Chair q/10 d/This is a wooden dining chair t/Furniture sp/50 cp/20`
 
 ### Listing all inventory items: `listi`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -297,7 +297,7 @@ the colour of the particular order's card will be in a darker shade than an unco
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 You can mark an order with insufficient stock as paid (to record payments for pre-orders) but you **cannot** 
-mark an order with **insufficient stock** as **delivered**. 
+mark an order as **delivered** if there is **insufficient stock** of the item(s) involved in the order. 
 </div>
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -296,7 +296,7 @@ Format: `marko INDEX [-p] [-d]`
 the colour of the particular order's card will be in a darker shade than an uncompleted order. 
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-You can mark an order with insufficient stock as paid (to record pre-payments) but you **cannot** 
+You can mark an order with insufficient stock as paid (to record payments for pre-orders) but you **cannot** 
 mark an order with **insufficient stock** as **delivered**. 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -276,6 +276,11 @@ Examples:
 
 Marks an existing order in the order list as paid and/or delivered. 
 
+<div markdown="block" class="alert alert-info">
+:information_source: **Warning:** `marko` is irreversible. This means that you cannot unmark an order that is marked as 
+paid and/or delivered. 
+</div>
+
 Format: `marko INDEX [-p] [-d]`
 
 * Marks the order at the specified `INDEX` as paid and/or delivered. 
@@ -289,6 +294,11 @@ Format: `marko INDEX [-p] [-d]`
 * Both `-p` and `-d` may be present in your input to mark an order as both paid and delivered.
 * When an order is completed (marked as both `paid` and `delivered`), 
 the colour of the particular order's card will be in a darker shade than an uncompleted order. 
+
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+You can mark an order with insufficient stock as paid (to record pre-payments) but you **cannot** 
+mark an order with **insufficient stock** as **delivered**. 
+</div>
 
 Examples:
 * `marko 1 -p` Marks the order at index `1` in the currently displayed list as `paid`. 


### PR DESCRIPTION
This PR contains fixes for User Guide bugs found by testers during PE-D. 

The following edits have been made to the UG
* Correct prefix of ITEM_NAME in `addi` to `i/` from the previous erroneous `n/` 
#150 

* Edit example given under `Features` section of ug to: 
"if the command specifies `i/ITEM_NAME q/QUANTITY`, `q/QUANTITY i/ITEM_NAME` is also acceptable" 
#158 

* Add details to clarify `marko` restrictions
> - Add warning that an order marked as paid and/or delivered cannot be unmarked
> #170 
> - Add rationale for allowing marking as paid on insufficient stock but not marking as delivered
> #182 
