### PR TITLE
Convert ArgumentToken wrapper class into an Interface

### DIFF
--- a/docs/diagrams/ParserClasses.puml
+++ b/docs/diagrams/ParserClasses.puml
@@ -15,10 +15,7 @@ Class CliSyntax
 Class ParserUtil
 Class ArgumentMultimap
 Class ArgumentTokenizer
-Class FlagTokenizer
-Class ArgumentToken
 Class Prefix
-Class Flag
 }
 
 Class HiddenOutside #FFFFFF

--- a/docs/diagrams/ParserClasses.puml
+++ b/docs/diagrams/ParserClasses.puml
@@ -15,7 +15,10 @@ Class CliSyntax
 Class ParserUtil
 Class ArgumentMultimap
 Class ArgumentTokenizer
+Class FlagTokenizer
+Class ArgumentToken
 Class Prefix
+Class Flag
 }
 
 Class HiddenOutside #FFFFFF

--- a/src/main/java/tracko/logic/parser/ArgumentToken.java
+++ b/src/main/java/tracko/logic/parser/ArgumentToken.java
@@ -1,7 +1,7 @@
 package tracko.logic.parser;
 
 /**
- * Wrapper class for tokens which signal argument inputs from user inputs
+ * Wrapper interface for tokens which signal argument inputs from user inputs
  */
 public interface ArgumentToken {
     String getToken();

--- a/src/main/java/tracko/logic/parser/ArgumentToken.java
+++ b/src/main/java/tracko/logic/parser/ArgumentToken.java
@@ -3,5 +3,6 @@ package tracko.logic.parser;
 /**
  * Wrapper class for tokens which signal argument inputs from user inputs
  */
-public class ArgumentToken {
+public interface ArgumentToken {
+    String getToken();
 }

--- a/src/main/java/tracko/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/tracko/logic/parser/ArgumentTokenizer.java
@@ -47,11 +47,11 @@ public class ArgumentTokenizer {
     private static List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
         List<PrefixPosition> positions = new ArrayList<>();
 
-        int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
+        int prefixPosition = findPrefixPosition(argsString, prefix.getToken(), 0);
         while (prefixPosition != -1) {
             PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
             positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+            prefixPosition = findPrefixPosition(argsString, prefix.getToken(), prefixPosition);
         }
 
         return positions;
@@ -118,7 +118,7 @@ public class ArgumentTokenizer {
                                         PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
 
-        int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
+        int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getToken().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
         return value.trim();

--- a/src/main/java/tracko/logic/parser/Flag.java
+++ b/src/main/java/tracko/logic/parser/Flag.java
@@ -4,19 +4,19 @@ package tracko.logic.parser;
  * A flag that marks the argument as true in an arguments string.
  * E.g. '-p' in 'marko 1 -p'.
  */
-public class Flag extends ArgumentToken {
+public class Flag implements ArgumentToken {
     private final String flag;
 
     public Flag(String flag) {
         this.flag = flag;
     }
 
-    public String getFlag() {
+    public String getToken() {
         return flag;
     }
 
     public String toString() {
-        return getFlag();
+        return getToken();
     }
 
     @Override
@@ -34,7 +34,7 @@ public class Flag extends ArgumentToken {
         }
 
         Flag otherPrefix = (Flag) obj;
-        return otherPrefix.getFlag().equals(getFlag());
+        return otherPrefix.getToken().equals(getToken());
     }
 }
 

--- a/src/main/java/tracko/logic/parser/FlagTokenizer.java
+++ b/src/main/java/tracko/logic/parser/FlagTokenizer.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
  * 1. Any input following the flag will be ignored.<br>
  * 2. If a flag exists, its corresponding argument value will be tokenized to the boolean {@code true}.<br>
  */
-public class FlagTokenizer extends ArgumentToken {
+public class FlagTokenizer {
     /**
      * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps flags to their
      * respective argument values. Only the given flags will be recognized in the arguments string.
@@ -44,11 +44,11 @@ public class FlagTokenizer extends ArgumentToken {
     private static List<FlagPosition> findFlagPositions(String argsString, Flag flag) {
         List<FlagPosition> positions = new ArrayList<>();
 
-        int flagPosition = findFlagPosition(argsString, flag.getFlag(), 0);
+        int flagPosition = findFlagPosition(argsString, flag.getToken(), 0);
         while (flagPosition != -1) {
             FlagPosition extendedFlag = new FlagPosition(flag, flagPosition);
             positions.add(extendedFlag);
-            flagPosition = findFlagPosition(argsString, flag.getFlag(), flagPosition);
+            flagPosition = findFlagPosition(argsString, flag.getToken(), flagPosition);
         }
 
         return positions;
@@ -116,7 +116,7 @@ public class FlagTokenizer extends ArgumentToken {
                                                FlagPosition nextFlagPosition) {
         Flag flag = currentFlagPosition.getFlag();
 
-        int valueStartPos = currentFlagPosition.getStartPosition() + flag.getFlag().length();
+        int valueStartPos = currentFlagPosition.getStartPosition() + flag.getToken().length();
         //value = preamble string when valueStartPos == 0
         String value = argsString.substring(valueStartPos, nextFlagPosition.getStartPosition());
 

--- a/src/main/java/tracko/logic/parser/Prefix.java
+++ b/src/main/java/tracko/logic/parser/Prefix.java
@@ -4,19 +4,19 @@ package tracko.logic.parser;
  * A prefix that marks the beginning of an argument in an arguments string.
  * E.g. 't/' in 'add James t/ friend'.
  */
-public class Prefix extends ArgumentToken {
+public class Prefix implements ArgumentToken {
     private final String prefix;
 
     public Prefix(String prefix) {
         this.prefix = prefix;
     }
 
-    public String getPrefix() {
+    public String getToken() {
         return prefix;
     }
 
     public String toString() {
-        return getPrefix();
+        return getToken();
     }
 
     @Override
@@ -34,6 +34,6 @@ public class Prefix extends ArgumentToken {
         }
 
         Prefix otherPrefix = (Prefix) obj;
-        return otherPrefix.getPrefix().equals(getPrefix());
+        return otherPrefix.getToken().equals(getToken());
     }
 }


### PR DESCRIPTION
In this PR, the `ArgumentToken` class, which currently acts as an empty wrapper class for both `Prefix` and `Flag`, is converted into an interface. 

This is to allow for better polymorphism rather than just having an empty wrapper class. 

I've re-run all the tests and everything still works. This PR changes the relationship between classes minimally (changes an `extends` relationship to an `implements` relationship)